### PR TITLE
Set charset on variables file

### DIFF
--- a/resources/scss/theme/_variables.scss
+++ b/resources/scss/theme/_variables.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8"
+
 // Variables
 //
 // Copy settings from this file into the provided `_custom.scss` to override


### PR DESCRIPTION
Fixes Invalid ASCII error in sass compilation from line 607 on $breadcrumb-divider
