### PR TITLE
Updated section divider to a pipe sign.

### DIFF
--- a/resources/scss/theme/layout/_sections.scss
+++ b/resources/scss/theme/layout/_sections.scss
@@ -26,7 +26,7 @@
             &:not(:last-child) {
                 a:after {
                     top: 0;
-                    content: '/';
+                    content: '|';
                     right: -0.75em;
                     position: absolute;
                     margin-top: -0.15em;


### PR DESCRIPTION
From a UX point of view, a pipe sign makes a lot more sense, otherwise it really looks like breadcrumbs.

![cursor_and_control_panel_ _fields](https://cloud.githubusercontent.com/assets/1143308/18746924/7fc503ac-80ca-11e6-984f-774769d25139.png)
